### PR TITLE
Improve detailed dependency-check output and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This project aggregates Dapla (Statistics Norway Data Platform) JavaScript sourc
 * Dependency-check.sh:
     * Improve splitting dependency versions into arrays
     * Improve if-statements
-    * Differentiate major/minor/path better (different colors?)
     * Potentially improve output when skipping devDependencies
         * Currently, might show both "0Major, 0Minor, 0Patch" (hidden devDep is outdated) or "Dependencies are up to
           date" (All deps are up-to-date)


### PR DESCRIPTION
Now has different colors for the three update types: Major, Minor and Patch
Fixed bug where outputting text to a terminal window that is smaller than the output text line, would not show the end of the current dependency output